### PR TITLE
Fix logoNav selector in siteheader.module.css

### DIFF
--- a/src/components/SiteHeader/SiteHeader.module.css
+++ b/src/components/SiteHeader/SiteHeader.module.css
@@ -5,20 +5,22 @@
   position: relative;
 }
 
-@media (min-width: 768px) {
-  .header {
-    height: 600px;
-    display: grid;
-    align-items: start;
-  }
-}
-
 .logoNav {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
+@media (min-width: 768px) {
+  .header {
+    height: 600px;
+    display: grid;
+    align-items: start;
+  }
+  .logoNav {
+    justify-content: center;
+  }
+}
 /* Remove active black color from anchor tags */
 
 a:-webkit-any-link {


### PR DESCRIPTION
desktop view:

![image](https://github.com/technative-academy/dragon/assets/143660964/21413a77-1170-4e78-b8e6-fdcb42a5487a)


added justify-content: center to logonav in siteheader.module.css