### PR TITLE
Clear the results when navigating away from the ask page

### DIFF
--- a/src/components/MainContent/AskPage/ResultsFeature/ResultsFeature.jsx
+++ b/src/components/MainContent/AskPage/ResultsFeature/ResultsFeature.jsx
@@ -1,14 +1,19 @@
 import ResultsCard from "./ResultsCard"
-import { useSelector } from "react-redux"
+import { useEffect } from "react"
+import { useSelector, useDispatch } from "react-redux"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faDragon } from "@fortawesome/free-solid-svg-icons"
 import styles from "./ResultsFeature.module.css"
+import { resetState } from "../QuestionFeature/questionFeatureSlice"
 
 function ResultsComponent() {
+  const dispatch = useDispatch()
   const results = useSelector((state) => state.question.results)
   const isLoading = useSelector((state) => state.question.isLoading)
   const hasError = useSelector((state) => state.question.hasError)
-
+  useEffect(() => {
+    dispatch(resetState())
+  }, [dispatch])
   if (isLoading) {
     return (
       <>


### PR DESCRIPTION
### Ask Page clear results

- Previously on navigation away from ask page and then return, the replies from the previously asked question would still be rendered. Fixed this issue using useEffect to reset the state of the replies when navigating away from page. 